### PR TITLE
switch newtork service readiness testing to netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
 	libxfixes3 \
 	libxml2 \
 	libxrandr2 \
+	netcat-traditional \
 	openbox \
 	pulseaudio \
 	x11-apps \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -18,6 +18,7 @@ RUN \
 	libxfixes3 \
 	libxml2 \
 	libxrandr2 \
+	netcat-traditional \
 	openbox \
 	pulseaudio \
 	x11-apps \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -18,6 +18,7 @@ RUN \
 	libxfixes3 \
 	libxml2 \
 	libxrandr2 \
+	netcat-traditional \
 	openbox \
 	pulseaudio \
 	x11-apps \

--- a/root/etc/services.d/xrdp/run
+++ b/root/etc/services.d/xrdp/run
@@ -4,7 +4,7 @@
 fdmove -c 2 1
 
 # Notify service manager when xrdp is up
-s6-notifyoncheck -w 500 -c "redirfd -w 1 /dev/null fdmove -c 2 1 s6-tcpclient 127.0.0.1 3389 true"
+s6-notifyoncheck -w 500 -c "redirfd -w 1 /dev/null fdmove -c 2 1 nc -w 1 -z -v 127.0.0.1 3389"
 
 # Wait until Xorg is running
 if { s6-svwait -t 10000 -U /var/run/s6/services/Xorg/ }


### PR DESCRIPTION
    * fixes linuxserver/docker-calibre#10

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
## Description:
Switch from s6-tcpclient to netcat for testing readiness of a services. 
s6-tcpclient seems to have issues on certain combinations of processor and/or kernels.

## Benefits of this PR and context:
Fixes ongoing issues with s6 service signalling.

## How Has This Been Tested?
New images were built and run. Everything operated within I would consider nominal. 


## Source / References:
linuxserver/docker-calibre#10
